### PR TITLE
feat: Improve parser error reporting and decouple AST

### DIFF
--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,21 @@
+feat: Improve parser error reporting and decouple AST
+
+This commit introduces two major improvements: a more robust error reporting system for the compiler and a significant architectural refactoring to improve separation of concerns.
+
+### Error Reporting Improvements
+
+The Lexer and Parser no longer throw an exception on the first error encountered. Instead, they now collect a list of all errors, allowing the CLI to present a comprehensive report to the user at once.
+
+- The Lexer now generates `Error` tokens for invalid syntax (e.g., unterminated strings, unrecognized characters) instead of throwing.
+- The Parser is now able to handle `Error` tokens and uses a synchronization strategy to recover from syntax errors and continue parsing. This allows it to detect multiple errors in a single pass.
+- The main program in `Betty.CLI` was updated to check for and display all collected errors from both the lexer and parser before attempting to interpret the code.
+- Tests were updated to assert that specific errors are collected, rather than asserting that an exception is thrown. A new test was added to verify that multiple, distinct errors are caught in a single run.
+
+### Architectural Refactoring (AST Decoupling)
+
+To improve separation of concerns and prepare for future compiler features (e.g., a bytecode compiler), the AST has been decoupled from the Interpreter.
+
+- The `IExpressionVisitor` and `IStatementVisitor` interfaces are now generic (`IExpressionVisitor<T>` and `IStatementVisitor<T>`).
+- This removes the direct dependency from the AST layer to the Interpreter's `Value` type. The AST is now a pure, reusable representation of the code's structure.
+- The Interpreter now implements the generic visitors (`IExpressionVisitor<Value>`, `IStatementVisitor<Value>`) and accepts a fully parsed `Program` node in its constructor, removing its responsibility for parsing logic.
+- All AST nodes and relevant tests have been updated to support the new generic visitor pattern.

--- a/src/Betty.CLI/Program.cs
+++ b/src/Betty.CLI/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Betty.Core;
 using Betty.Core.Interpreter;
+using BettyProgram = Betty.Core.AST.Program;
 
 namespace Betty.CLI
 {
@@ -25,8 +26,36 @@ namespace Betty.CLI
             {
                 string source = File.ReadAllText(path);
                 var lexer = new Lexer(source);
-                var parser = new Parser(lexer);
-                var interpreter = new Interpreter(parser);
+                var tokens = lexer.GetTokens();
+
+                if (lexer.Errors.Count > 0)
+                {
+                    foreach (var error in lexer.Errors)
+                    {
+                        Console.WriteLine(error);
+                    }
+                    return;
+                }
+
+                var parser = new Parser(tokens);
+                var ast = parser.Parse();
+
+                if (parser.Errors.Count > 0)
+                {
+                    foreach (var error in parser.Errors)
+                    {
+                        Console.WriteLine(error);
+                    }
+                    return;
+                }
+
+                if (ast is not BettyProgram programNode)
+                {
+                    Console.WriteLine("Fatal error: Could not parse the input into a valid program structure.");
+                    return;
+                }
+
+                var interpreter = new Interpreter(programNode);
                 interpreter.Interpret();
             }
             catch (Exception ex)
@@ -125,8 +154,36 @@ namespace Betty.CLI
 
                 // Create lexer, parser, and interpreter
                 var lexer = new Lexer(source);
-                var parser = new Parser(lexer);
-                var interpreter = new Interpreter(parser);
+                var tokens = lexer.GetTokens();
+
+                if (lexer.Errors.Count > 0)
+                {
+                    foreach (var error in lexer.Errors)
+                    {
+                        Console.WriteLine(error);
+                    }
+                    return;
+                }
+
+                var parser = new Parser(tokens);
+                var ast = parser.Parse();
+
+                if (parser.Errors.Count > 0)
+                {
+                    foreach (var error in parser.Errors)
+                    {
+                        Console.WriteLine(error);
+                    }
+                    return;
+                }
+
+                if (ast is not BettyProgram programNode)
+                {
+                    Console.WriteLine("Fatal error: Could not parse the input into a valid program structure.");
+                    return;
+                }
+
+                var interpreter = new Interpreter(programNode);
 
                 // Run the program
                 Console.WriteLine("--- Program Output ---");

--- a/src/Betty.Core/AST/Expression.cs
+++ b/src/Betty.Core/AST/Expression.cs
@@ -1,9 +1,7 @@
-﻿using Betty.Core.Interpreter;
-
-namespace Betty.Core.AST
+﻿namespace Betty.Core.AST
 {
     public abstract class Expression
     {
-        public abstract Value Accept(IExpressionVisitor visitor);
+        public abstract T Accept<T>(IExpressionVisitor<T> visitor);
     }
 }

--- a/src/Betty.Core/AST/Expressions/AssignmentExpression.cs
+++ b/src/Betty.Core/AST/Expressions/AssignmentExpression.cs
@@ -8,6 +8,6 @@ namespace Betty.Core.AST
         public Expression Right { get; } = right;
         public TokenType OperatorType { get; } = operatorType;
 
-        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IExpressionVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Expressions/BinaryOperatorExpression.cs
+++ b/src/Betty.Core/AST/Expressions/BinaryOperatorExpression.cs
@@ -8,6 +8,6 @@ namespace Betty.Core.AST
         public TokenType Operator { get; } = op;
         public Expression Right { get; } = right;
 
-        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IExpressionVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Expressions/BooleanExpression.cs
+++ b/src/Betty.Core/AST/Expressions/BooleanExpression.cs
@@ -6,6 +6,6 @@ namespace Betty.Core.AST
     {
         public bool Value { get; } = value;
 
-        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IExpressionVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Expressions/CharLiteral.cs
+++ b/src/Betty.Core/AST/Expressions/CharLiteral.cs
@@ -6,6 +6,6 @@ namespace Betty.Core.AST
     {
         public char Value { get; } = value;
 
-        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IExpressionVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Expressions/ErrorExpression.cs
+++ b/src/Betty.Core/AST/Expressions/ErrorExpression.cs
@@ -1,0 +1,11 @@
+namespace Betty.Core.AST.Expressions;
+
+public class ErrorExpression : Expression
+{
+    public override T Accept<T>(IExpressionVisitor<T> visitor)
+    {
+        // This should not be called.
+        // The interpreter should not try to evaluate an error expression.
+        throw new NotImplementedException();
+    }
+}

--- a/src/Betty.Core/AST/Expressions/FunctionCall.cs
+++ b/src/Betty.Core/AST/Expressions/FunctionCall.cs
@@ -10,6 +10,6 @@ namespace Betty.Core.AST
         public Expression? Expression = expression;
         public string? FunctionName = functionName;
 
-        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IExpressionVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Expressions/FunctionExpression.cs
+++ b/src/Betty.Core/AST/Expressions/FunctionExpression.cs
@@ -8,6 +8,6 @@ namespace Betty.Core.AST
         public List<string> Parameters { get; } = parameters;
         public CompoundStatement Body { get; } = body;
 
-        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IExpressionVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Expressions/IfExpression.cs
+++ b/src/Betty.Core/AST/Expressions/IfExpression.cs
@@ -13,6 +13,6 @@ namespace Betty.Core.AST
         public List<(Expression Condition, Expression Expression)> ElseIfExpressions { get; } = elseIfExpressions;
         public Expression ElseExpression { get; } = elseExpression;
 
-        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IExpressionVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Expressions/IndexerExpression.cs
+++ b/src/Betty.Core/AST/Expressions/IndexerExpression.cs
@@ -7,6 +7,6 @@ namespace Betty.Core.AST
         public Expression Collection { get; } = collection;
         public Expression Index { get; } = index;
 
-        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IExpressionVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Expressions/ListLiteral.cs
+++ b/src/Betty.Core/AST/Expressions/ListLiteral.cs
@@ -6,6 +6,6 @@ namespace Betty.Core.AST
     {
         public List<Expression> Elements { get; } = elements;
 
-        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IExpressionVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Expressions/NumberLiteral.cs
+++ b/src/Betty.Core/AST/Expressions/NumberLiteral.cs
@@ -6,6 +6,6 @@ namespace Betty.Core.AST
     {
         public double Value { get; } = value;
 
-        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IExpressionVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Expressions/Program.cs
+++ b/src/Betty.Core/AST/Expressions/Program.cs
@@ -7,6 +7,6 @@ namespace Betty.Core.AST
         public List<string> Globals { get; } = globals;
         public List<FunctionDefinition> Functions { get; } = functions;
 
-        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IExpressionVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Expressions/StringLiteral.cs
+++ b/src/Betty.Core/AST/Expressions/StringLiteral.cs
@@ -6,6 +6,6 @@ namespace Betty.Core.AST
     {
         public string Value { get; } = value;
 
-        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IExpressionVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Expressions/TernaryOperatorExpression.cs
+++ b/src/Betty.Core/AST/Expressions/TernaryOperatorExpression.cs
@@ -8,6 +8,6 @@ namespace Betty.Core.AST
         public Expression TrueExpression { get; } = trueExpression;
         public Expression FalseExpression { get; } = falseExpression;
 
-        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IExpressionVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Expressions/UnaryOperatorExpression.cs
+++ b/src/Betty.Core/AST/Expressions/UnaryOperatorExpression.cs
@@ -14,6 +14,6 @@ namespace Betty.Core.AST
         public TokenType Operator { get; } = op;
         public OperatorFixity Fixity { get; } = fixity;
 
-        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IExpressionVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Expressions/Variable.cs
+++ b/src/Betty.Core/AST/Expressions/Variable.cs
@@ -6,6 +6,6 @@ namespace Betty.Core.AST
     {
         public string Name { get; } = name;
 
-        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IExpressionVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/IExpressionVisitor.cs
+++ b/src/Betty.Core/AST/IExpressionVisitor.cs
@@ -1,23 +1,24 @@
-﻿using Betty.Core.Interpreter;
+﻿using Betty.Core.AST.Expressions;
 
 namespace Betty.Core.AST
 {
-    public interface IExpressionVisitor
+    public interface IExpressionVisitor<T>
     {
-        Value Visit(NumberLiteral node);
-        Value Visit(BooleanExpression node);
-        Value Visit(StringLiteral node);
-        Value Visit(CharLiteral node);
-        Value Visit(BinaryOperatorExpression node);
-        Value Visit(TernaryOperatorExpression node);
-        Value Visit(UnaryOperatorExpression node);
-        Value Visit(Variable node);
-        Value Visit(FunctionCall node);
-        Value Visit(Program node);
-        Value Visit(AssignmentExpression node);
-        Value Visit(IndexerExpression node);
-        Value Visit(ListLiteral node);
-        Value Visit(FunctionExpression node);
-        Value Visit(IfExpression node);
+        T Visit(NumberLiteral node);
+        T Visit(BooleanExpression node);
+        T Visit(StringLiteral node);
+        T Visit(CharLiteral node);
+        T Visit(BinaryOperatorExpression node);
+        T Visit(TernaryOperatorExpression node);
+        T Visit(UnaryOperatorExpression node);
+        T Visit(Variable node);
+        T Visit(FunctionCall node);
+        T Visit(Program node);
+        T Visit(AssignmentExpression node);
+        T Visit(IndexerExpression node);
+        T Visit(ListLiteral node);
+        T Visit(FunctionExpression node);
+        T Visit(IfExpression node);
+        T Visit(ErrorExpression node);
     }
 }

--- a/src/Betty.Core/AST/IStatementVisitor.cs
+++ b/src/Betty.Core/AST/IStatementVisitor.cs
@@ -1,18 +1,18 @@
 ﻿namespace Betty.Core.AST
 {
-    public interface IStatementVisitor
+    public interface IStatementVisitor<T>
     {
-        void Visit(IfStatement node);
-        void Visit(ForStatement node);
-        void Visit(ForEachStatement node);
-        void Visit(WhileStatement node);
-        void Visit(DoWhileStatement node);
-        void Visit(BreakStatement node);
-        void Visit(ContinueStatement node);
-        void Visit(ReturnStatement node);
-        void Visit(EmptyStatement node);
-        void Visit(FunctionDefinition node);
-        void Visit(CompoundStatement node);
-        void Visit(ExpressionStatement node);
+        T Visit(IfStatement node);
+        T Visit(ForStatement node);
+        T Visit(ForEachStatement node);
+        T Visit(WhileStatement node);
+        T Visit(DoWhileStatement node);
+        T Visit(BreakStatement node);
+        T Visit(ContinueStatement node);
+        T Visit(ReturnStatement node);
+        T Visit(EmptyStatement node);
+        T Visit(FunctionDefinition node);
+        T Visit(CompoundStatement node);
+        T Visit(ExpressionStatement node);
     }
 }

--- a/src/Betty.Core/AST/Statement.cs
+++ b/src/Betty.Core/AST/Statement.cs
@@ -2,6 +2,6 @@
 {
     public abstract class Statement
     {
-        public abstract void Accept(IStatementVisitor visitor);
+        public abstract T Accept<T>(IStatementVisitor<T> visitor);
     }
 }

--- a/src/Betty.Core/AST/Statements/BreakStatement.cs
+++ b/src/Betty.Core/AST/Statements/BreakStatement.cs
@@ -2,6 +2,6 @@
 {
     public class BreakStatement : Statement
     {
-        public override void Accept(IStatementVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IStatementVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Statements/CompoundStatement.cs
+++ b/src/Betty.Core/AST/Statements/CompoundStatement.cs
@@ -4,6 +4,6 @@
     {
         public List<Statement> Statements { get; } = [];
 
-        public override void Accept(IStatementVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IStatementVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Statements/ContinueStatement.cs
+++ b/src/Betty.Core/AST/Statements/ContinueStatement.cs
@@ -2,6 +2,6 @@
 {
     public class ContinueStatement : Statement
     {
-        public override void Accept(IStatementVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IStatementVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Statements/DoWhileStatement.cs
+++ b/src/Betty.Core/AST/Statements/DoWhileStatement.cs
@@ -5,6 +5,6 @@
         public Expression Condition { get; } = condition;
         public Statement Body { get; } = body;
 
-        public override void Accept(IStatementVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IStatementVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Statements/EmptyStatement.cs
+++ b/src/Betty.Core/AST/Statements/EmptyStatement.cs
@@ -2,6 +2,6 @@
 {
     public class EmptyStatement : Statement
     {
-        public override void Accept(IStatementVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IStatementVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Statements/ExpressionStatement.cs
+++ b/src/Betty.Core/AST/Statements/ExpressionStatement.cs
@@ -4,6 +4,6 @@
     {
         public Expression Expression { get; } = expression;
 
-        public override void Accept(IStatementVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IStatementVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Statements/ForEachStatement.cs
+++ b/src/Betty.Core/AST/Statements/ForEachStatement.cs
@@ -6,6 +6,6 @@
         public Expression Iterable { get; } = iterable;
         public Statement Body { get; } = body;
 
-        public override void Accept(IStatementVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IStatementVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Statements/ForStatement.cs
+++ b/src/Betty.Core/AST/Statements/ForStatement.cs
@@ -11,6 +11,6 @@
         public Expression? Increment { get; } = increment;
         public Statement Body { get; } = body;
 
-        public override void Accept(IStatementVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IStatementVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Statements/FunctionDefinition.cs
+++ b/src/Betty.Core/AST/Statements/FunctionDefinition.cs
@@ -6,6 +6,6 @@
         public List<string> Parameters { get; } = parameters;
         public CompoundStatement Body { get; } = body;
 
-        public override void Accept(IStatementVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IStatementVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Statements/IfStatement.cs
+++ b/src/Betty.Core/AST/Statements/IfStatement.cs
@@ -11,6 +11,6 @@
         public List<(Expression Condition, Statement Statement)> ElseIfStatements { get; } = elseIfStatements;
         public Statement? ElseStatement { get; } = elseStatement;
 
-        public override void Accept(IStatementVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IStatementVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Statements/ReturnStatement.cs
+++ b/src/Betty.Core/AST/Statements/ReturnStatement.cs
@@ -4,6 +4,6 @@
     {
         public Expression? ReturnValue { get; } = returnValue;
 
-        public override void Accept(IStatementVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IStatementVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/AST/Statements/WhileStatement.cs
+++ b/src/Betty.Core/AST/Statements/WhileStatement.cs
@@ -5,6 +5,6 @@
         public Expression Condition { get; } = condition;
         public Statement Body { get; } = body;
 
-        public override void Accept(IStatementVisitor visitor) => visitor.Visit(this);
+        public override T Accept<T>(IStatementVisitor<T> visitor) => visitor.Visit(this);
     }
 }

--- a/src/Betty.Core/Errors/Error.cs
+++ b/src/Betty.Core/Errors/Error.cs
@@ -1,0 +1,13 @@
+namespace Betty.Core.Errors;
+
+public class Error(string message, int line, int column)
+{
+    public string Message { get; } = message;
+    public int Line { get; } = line;
+    public int Column { get; } = column;
+
+    public override string ToString()
+    {
+        return $"Error at {Line}:{Column}: {Message}";
+    }
+}

--- a/src/Betty.Core/Interpreter/FunctionHandlers.cs
+++ b/src/Betty.Core/Interpreter/FunctionHandlers.cs
@@ -5,12 +5,13 @@ namespace Betty.Core.Interpreter
 {
     public partial class Interpreter
     {
-        public void Visit(FunctionDefinition node)
+        public Value Visit(FunctionDefinition node)
         {
             if (_intrinsicFunctions.ContainsKey(node.FunctionName!))
                 throw new Exception($"Function name '{node.FunctionName}' is reserved for built-in functions.");
 
             _functions[node.FunctionName!] = node;
+            return Value.None();
         }
 
         public Value Visit(FunctionCall node)

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/Char/IsDigitFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/Char/IsDigitFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public IsDigitFunction() : base("isdigit") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 1);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/Char/IsSpaceFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/Char/IsSpaceFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public IsSpaceFunction() : base("isspace") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 1);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/Conversion/ToBooleanFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/Conversion/ToBooleanFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public ToBooleanFunction() : base("tobool") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 1);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/Conversion/ToCharFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/Conversion/ToCharFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public ToCharFunction() : base("tochar") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 1);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/Conversion/ToListFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/Conversion/ToListFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public ToListFunction() : base("tolist") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 1);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/Conversion/ToNumberFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/Conversion/ToNumberFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public ToNumberFunction() : base("tonum") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 1);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/Conversion/ToStringFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/Conversion/ToStringFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public ToStringFunction() : base("tostr") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 1);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/IO/InputFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/IO/InputFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public InputFunction() : base("input") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 0, 1);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/IO/PrintFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/IO/PrintFunction.cs
@@ -7,7 +7,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public PrintFunction() : base("print") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             var stringBuilder = new StringBuilder();
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/IntrinsicFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/IntrinsicFunction.cs
@@ -11,7 +11,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
             Name = name;
         }
 
-        public abstract Value Execute(IExpressionVisitor visitor, FunctionCall call);
+        public abstract Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call);
 
         protected void ValidateArgumentCount(FunctionCall call, int expectedCount)
         {

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/List/AppendFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/List/AppendFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public AppendFunction() : base("append") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 2);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/List/CloneFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/List/CloneFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public CloneFunction() : base("clone") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 1);
             var valueToClone = call.Arguments[0].Accept(visitor);

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/List/LengthFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/List/LengthFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public LengthFunction() : base("len") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 1);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/List/RangeFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/List/RangeFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public RangeFunction() : base("range") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 2);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/List/RemoveAtFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/List/RemoveAtFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public RemoveAtFunction() : base("removeat") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 2);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/List/RemoveFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/List/RemoveFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public RemoveFunction() : base("remove") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 2);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/Math/AbsFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/Math/AbsFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public AbsFunction() : base("abs") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 1);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/Math/CeilFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/Math/CeilFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public CeilFunction() : base("ceil") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 1);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/Math/CosFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/Math/CosFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public CosFunction() : base("cos") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 1);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/Math/FloorFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/Math/FloorFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public FloorFunction() : base("floor") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 1);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/Math/PowFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/Math/PowFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public PowFunction() : base("pow") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 2);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/Math/SinFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/Math/SinFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public SinFunction() : base("sin") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 1);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/Math/SqrtFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/Math/SqrtFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public SqrtFunction() : base("sqrt") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 1);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/Math/TanFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/Math/TanFunction.cs
@@ -6,7 +6,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public TanFunction() : base("tan") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             ValidateArgumentCount(call, 1);
 

--- a/src/Betty.Core/Interpreter/IntrinsicFunctions/String/ConcatFunction.cs
+++ b/src/Betty.Core/Interpreter/IntrinsicFunctions/String/ConcatFunction.cs
@@ -7,7 +7,7 @@ namespace Betty.Core.Interpreter.IntrinsicFunctions
     {
         public ConcatFunction() : base("concat") { }
 
-        public override Value Execute(IExpressionVisitor visitor, FunctionCall call)
+        public override Value Execute(IExpressionVisitor<Value> visitor, FunctionCall call)
         {
             var stringBuilder = new StringBuilder();
 

--- a/src/Betty.Core/Token.cs
+++ b/src/Betty.Core/Token.cs
@@ -28,6 +28,7 @@
         GreaterThanOrEqual, NotEqual,
 
         // Special tokens
+        Error,
         EOF
     }
 

--- a/src/Betty.Tests/InterpreterTests/ErrorHandlingTests.cs
+++ b/src/Betty.Tests/InterpreterTests/ErrorHandlingTests.cs
@@ -1,0 +1,34 @@
+using Betty.Core;
+using Betty.Tests.TestUtilities;
+
+namespace Betty.Tests.InterpreterTests
+{
+    public class ErrorHandlingTests : InterpreterTestBase
+    {
+        [Fact]
+        public void Interpreter_Catches_Multiple_Errors()
+        {
+            var code = @"
+func main() {
+    a = 1;
+    b = .; // Invalid character
+    c = 'unterminated;
+    d = ""another unterminated;
+    e = 1 +;
+}";
+
+            var lexer = new Lexer(code);
+            var tokens = lexer.GetTokens();
+            var parser = new Parser(tokens);
+            parser.Parse();
+
+            var errorMessages = lexer.Errors.Concat(parser.Errors).Select(e => e.Message).ToList();
+
+            Assert.Contains("Unrecognized character: .", errorMessages);
+            Assert.Contains("Unterminated character literal.", errorMessages);
+            Assert.Contains("Unterminated string literal.", errorMessages);
+            Assert.Contains("Unexpected token: Error", errorMessages);
+            Assert.Contains("Unexpected token: Expected Semicolon, found Identifier", errorMessages);
+        }
+    }
+}

--- a/src/Betty.Tests/LexerTests/LiteralTests.cs
+++ b/src/Betty.Tests/LexerTests/LiteralTests.cs
@@ -21,25 +21,35 @@
         }
 
         [Fact]
-        public void GetNextToken_ThrowsExceptionForEmptyCharLiteral()
+        public void GetNextToken_AddsErrorForEmptyCharLiteral()
         {
             // Arrange
             var input = "''";
             var lexer = new Lexer(input);
 
-            // Act & Assert
-            Assert.Throws<Exception>(() => lexer.GetNextToken());
+            // Act
+            var token = lexer.GetNextToken();
+
+            // Assert
+            Assert.Equal(TokenType.Error, token.Type);
+            Assert.Single(lexer.Errors);
+            Assert.Equal("Empty character literal.", lexer.Errors[0].Message);
         }
 
         [Fact]
-        public void GetNextToken_ThrowsExceptionForUnterminatedCharLiteral()
+        public void GetNextToken_AddsErrorForUnterminatedCharLiteral()
         {
             // Arrange
             var input = "'a";
             var lexer = new Lexer(input);
 
-            // Act & Assert
-            Assert.Throws<Exception>(() => lexer.GetNextToken());
+            // Act
+            var token = lexer.GetNextToken();
+
+            // Assert
+            Assert.Equal(TokenType.Error, token.Type);
+            Assert.Single(lexer.Errors);
+            Assert.Equal("Unterminated character literal.", lexer.Errors[0].Message);
         }
 
         [Theory]
@@ -90,25 +100,35 @@
         }
 
         [Fact]
-        public void ScanStringLiteral_ThrowsExceptionForUnterminatedString()
+        public void ScanStringLiteral_AddsErrorForUnterminatedString()
         {
             // Arrange
             var input = "\"Hello";
             var lexer = new Lexer(input);
 
-            // Act & Assert
-            Assert.Throws<Exception>(() => lexer.GetNextToken());
+            // Act
+            var token = lexer.GetNextToken();
+
+            // Assert
+            Assert.Equal(TokenType.Error, token.Type);
+            Assert.Single(lexer.Errors);
+            Assert.Equal("Unterminated string literal.", lexer.Errors[0].Message);
         }
 
         [Fact]
-        public void ScanStringLiteral_ThrowsExceptionForUnrecognizedEscapeSequence()
+        public void ScanStringLiteral_AddsErrorForUnrecognizedEscapeSequence()
         {
             // Arrange
             var input = "\"Hello\\x\"";
             var lexer = new Lexer(input);
 
-            // Act & Assert
-            Assert.Throws<Exception>(() => lexer.GetNextToken());
+            // Act
+            var token = lexer.GetNextToken();
+
+            // Assert
+            Assert.Equal(TokenType.Error, token.Type);
+            Assert.Single(lexer.Errors);
+            Assert.Equal("Unrecognized escape sequence: \\x", lexer.Errors[0].Message);
         }
     }
 }

--- a/src/Betty.Tests/ParserTests/FunctionTests.cs
+++ b/src/Betty.Tests/ParserTests/FunctionTests.cs
@@ -59,10 +59,9 @@
         {
             var code = "func emptyFunc()";
             var parser = SetupParser(code);
-            var exception = Record.Exception(() => parser.Parse());
+            parser.Parse();
 
-            Assert.NotNull(exception);
-            Assert.IsType<Exception>(exception);
+            Assert.NotEmpty(parser.Errors);
         }
 
         [Fact]

--- a/src/Betty.Tests/ParserTests/RecursionTests.cs
+++ b/src/Betty.Tests/ParserTests/RecursionTests.cs
@@ -13,7 +13,9 @@
                 }
             ";
 
-            var parser = new Parser(new Lexer(code));
+            var lexer = new Lexer(code);
+            var tokens = lexer.GetTokens();
+            var parser = new Parser(tokens);
             var programNode = parser.Parse() as Program;
 
             // Assert that the program node is not null

--- a/src/Betty.Tests/TestUtilities/InterpreterTestBase.cs
+++ b/src/Betty.Tests/TestUtilities/InterpreterTestBase.cs
@@ -6,10 +6,11 @@ namespace Betty.Tests.TestUtilities
     {
         protected static Interpreter SetupInterpreter(string code, bool customSetup = false)
         {
-            return new Interpreter(
-                new Parser(
-                    new Lexer(
-                        customSetup ? code : $"func main() {{ {code} }}")));
+            var lexer = new Lexer(customSetup ? code : $"func main() {{ {code} }}");
+            var tokens = lexer.GetTokens();
+            var parser = new Parser(tokens);
+            var program = (Program)parser.Parse();
+            return new Interpreter(program);
         }
     }
 }

--- a/src/Betty.Tests/TestUtilities/ParserTestBase.cs
+++ b/src/Betty.Tests/TestUtilities/ParserTestBase.cs
@@ -5,7 +5,8 @@
         protected static Parser SetupParser(string code)
         {
             var lexer = new Lexer(code);
-            return new Parser(lexer);
+            var tokens = lexer.GetTokens();
+            return new Parser(tokens);
         }
     }
 }


### PR DESCRIPTION
This commit introduces two major improvements: a more robust error reporting system for the compiler and a significant architectural refactoring to improve separation of concerns.

### Error Reporting Improvements

The Lexer and Parser no longer throw an exception on the first error encountered. Instead, they now collect a list of all errors, allowing the CLI to present a comprehensive report to the user at once.

- The Lexer now generates `Error` tokens for invalid syntax (e.g., unterminated strings, unrecognized characters) instead of throwing.
- The Parser is now able to handle `Error` tokens and uses a synchronization strategy to recover from syntax errors and continue parsing. This allows it to detect multiple errors in a single pass.
- The main program in `Betty.CLI` was updated to check for and display all collected errors from both the lexer and parser before attempting to interpret the code.
- Tests were updated to assert that specific errors are collected, rather than asserting that an exception is thrown. A new test was added to verify that multiple, distinct errors are caught in a single run.

### Architectural Refactoring (AST Decoupling)

To improve separation of concerns and prepare for future compiler features (e.g., a bytecode compiler), the AST has been decoupled from the Interpreter.

- The `IExpressionVisitor` and `IStatementVisitor` interfaces are now generic (`IExpressionVisitor<T>` and `IStatementVisitor<T>`).
- This removes the direct dependency from the AST layer to the Interpreter's `Value` type. The AST is now a pure, reusable representation of the code's structure.
- The Interpreter now implements the generic visitors (`IExpressionVisitor<Value>`, `IStatementVisitor<Value>`) and accepts a fully parsed `Program` node in its constructor, removing its responsibility for parsing logic.
- All AST nodes and relevant tests have been updated to support the new generic visitor pattern.