### PR TITLE
feat: implement switch expressions with proper closure support

### DIFF
--- a/src/Betty.Core/AST/Expressions/SwitchExpression.cs
+++ b/src/Betty.Core/AST/Expressions/SwitchExpression.cs
@@ -1,0 +1,27 @@
+﻿using Betty.Core.Interpreter;
+
+namespace Betty.Core.AST
+{
+    public class SwitchExpressionCase
+    {
+        public Expression? CaseExpression { get; }
+        public Expression ResultExpression { get; }
+        public SwitchExpressionCase(Expression? caseExpression, Expression resultExpression)
+        {
+            CaseExpression = caseExpression;
+            ResultExpression = resultExpression;
+        }
+    }
+
+    public class SwitchExpression : Expression
+    {
+        public Expression Expression { get; }
+        public List<SwitchExpressionCase> Cases { get; }
+        public SwitchExpression(Expression expression, List<SwitchExpressionCase> cases)
+        {
+            Expression = expression;
+            Cases = cases;
+        }
+        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+    }
+}

--- a/src/Betty.Core/AST/IExpressionVisitor.cs
+++ b/src/Betty.Core/AST/IExpressionVisitor.cs
@@ -19,5 +19,6 @@ namespace Betty.Core.AST
         Value Visit(ListLiteral node);
         Value Visit(FunctionExpression node);
         Value Visit(IfExpression node);
+        Value Visit(SwitchExpression node);
     }
 }

--- a/src/Betty.Core/Interpreter/FunctionValue.cs
+++ b/src/Betty.Core/Interpreter/FunctionValue.cs
@@ -1,0 +1,16 @@
+﻿using Betty.Core.AST;
+
+namespace Betty.Core.Interpreter
+{
+    public class FunctionValue
+    {
+        public FunctionExpression Expression { get; }
+        public Dictionary<string, Value> CapturedScope { get; }
+
+        public FunctionValue(FunctionExpression expression, Dictionary<string, Value> capturedScope)
+        {
+            Expression = expression;
+            CapturedScope = capturedScope;
+        }
+    }
+}

--- a/src/Betty.Core/Interpreter/ScopeManager.cs
+++ b/src/Betty.Core/Interpreter/ScopeManager.cs
@@ -71,5 +71,23 @@
 
             throw new Exception($"Variable '{name}' is not defined in any (active) scope.");
         }
+
+        // Captures all currently accessible variables
+        public Dictionary<string, Value> GetAllVariables()
+        {
+            var result = new Dictionary<string, Value>(_globals);
+
+            // Add local scopes from outermost to innermost
+            // so inner scopes override outer ones
+            foreach (var scope in _scopes.Reverse())
+            {
+                foreach (var kvp in scope)
+                {
+                    result[kvp.Key] = kvp.Value;
+                }
+            }
+
+            return result;
+        }
     }
 }

--- a/src/Betty.Core/Lexer.cs
+++ b/src/Betty.Core/Lexer.cs
@@ -29,7 +29,8 @@
             ["return"] = TokenType.Return,
             ["switch"] = TokenType.Switch,
             ["case"] = TokenType.Case,
-            ["default"] = TokenType.Default
+            ["default"] = TokenType.Default,
+            ["_"] = TokenType.Underscore
         };
 
         private static readonly Dictionary<char, TokenType> _singleCharOperators = new()
@@ -74,7 +75,8 @@
             ["^="] = TokenType.CaretEqual,
             ["%="] = TokenType.ModEqual,
             ["//"] = TokenType.IntDiv,
-            ["//="] = TokenType.IntDivEqual
+            ["//="] = TokenType.IntDivEqual,
+            ["=>"] = TokenType.Arrow
         };
 
         public Lexer(string input)

--- a/src/Betty.Core/Parser.cs
+++ b/src/Betty.Core/Parser.cs
@@ -183,7 +183,7 @@ namespace Betty.Core
             // Step 1: Handle primary expressions and unary operators
             Expression expr = ParsePrefix();
 
-            // Step 2: Loop to handle postfix operations (function calls, indexers, postfix operators)
+            // Step 2: Loop to handle postfix operations (function calls, indexers, postfix operators, switch expressions)
             while (true)
             {
                 switch (_currentToken.Type)
@@ -206,11 +206,52 @@ namespace Betty.Core
                         expr = new UnaryOperatorExpression(expr, operatorToken.Type, OperatorFixity.Postfix);
                         break;
 
+                    case TokenType.Switch:
+                        // Switch expression (postfix operation)
+                        expr = ParseSwitchExpression(expr);
+                        break;
+
                     default:
                         // No postfix operation, return the expression
                         return expr;
                 }
             }
+        }
+
+        private SwitchExpression ParseSwitchExpression(Expression expr)
+        {
+            Consume(TokenType.Switch);
+            Consume(TokenType.LBrace);
+            var cases = new List<SwitchExpressionCase>();
+            while (_currentToken.Type != TokenType.RBrace)
+            {
+                if (_currentToken.Type == TokenType.Underscore)  // Checking for default '_'
+                    break;  // Stop parsing regular cases if we encounter '_'
+
+                var condition = ParseExpression();
+                Consume(TokenType.Arrow);
+
+                var caseResult = ParseExpression();
+
+                cases.Add(new SwitchExpressionCase(condition, caseResult));
+
+                if (_currentToken.Type == TokenType.Comma)
+                {
+                    Consume(TokenType.Comma); // Consume comma between cases
+                }
+            }
+
+            // Handle default case if present
+            if (_currentToken.Type == TokenType.Underscore) // Default case indicated by '_'
+            {
+                Consume(TokenType.Underscore);
+                Consume(TokenType.Arrow);
+                var defaultResult = ParseExpression();
+                cases.Add(new SwitchExpressionCase(null, defaultResult));
+            }
+
+            Consume(TokenType.RBrace);
+            return new SwitchExpression(expr, cases);
         }
 
         private Expression ParsePrefix()

--- a/src/Betty.Core/Token.cs
+++ b/src/Betty.Core/Token.cs
@@ -13,12 +13,12 @@
 
         // Punctuation
         LParen, RParen, LBrace, RBrace, LBracket, RBracket, 
-        Semicolon, Comma, QuestionMark, Colon, DotDot,
+        Semicolon, Comma, QuestionMark, Colon, DotDot, Arrow,
 
         // Keywords/identifiers
         Func, Global, TrueKeyword, FalseKeyword, Identifier,
         If, Then, Elif, Else, For, ForEach, In, While, Do, Break, Continue, Return,
-        Switch, Case, Default,
+        Switch, Case, Default, Underscore,
 
         // Assignment operators
         Equal, Increment, Decrement, PlusEqual, MinusEqual,

--- a/src/Betty.Tests/InterpreterTests/ConditionalStatementTests.cs
+++ b/src/Betty.Tests/InterpreterTests/ConditionalStatementTests.cs
@@ -3,6 +3,494 @@
     public class ConditionalStatementTests : InterpreterTestBase
     {
         [Fact]
+        public void SwitchExpression_WithLambdaResults()
+        {
+            var code = @"
+        func main() {
+            operation = ""square"";
+            fn = operation switch {
+                ""square"" => func(x) { return x * x; },
+                ""double"" => func(x) { return x * 2; },
+                ""increment"" => func(x) { return x + 1; },
+                _ => func(x) { return x; }
+            };
+            return fn(5);
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(25, result.AsNumber());
+        }
+
+        [Fact]
+        public void SwitchExpression_ReturningDifferentLambdas()
+        {
+            var code = @"
+        func main() {
+            mode = 2;
+            calculator = mode switch {
+                1 => func(a, b) { return a + b; },
+                2 => func(a, b) { return a * b; },
+                3 => func(a, b) { return a - b; },
+                _ => func(a, b) { return 0; }
+            };
+            return calculator(7, 3);
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(21, result.AsNumber());
+        }
+
+        [Fact]
+        public void SwitchExpression_OnLambdaResult()
+        {
+            var code = @"
+        func main() {
+            getValue = func() { return 3; };
+            result = getValue() switch {
+                1 => ""One"",
+                2 => ""Two"",
+                3 => ""Three"",
+                _ => ""Other""
+            };
+            return result;
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal("Three", result.AsString());
+        }
+
+        [Fact]
+        public void SwitchExpression_WithClosureCapture()
+        {
+            var code = @"
+        func main() {
+            multiplier = 10;
+            type = ""add"";
+            operation = type switch {
+                ""add"" => func(x) { return x + multiplier; },
+                ""multiply"" => func(x) { return x * multiplier; },
+                _ => func(x) { return x; }
+            };
+            return operation(5);
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(15, result.AsNumber());
+        }
+
+        [Fact]
+        public void SwitchExpression_NestedWithLambdas()
+        {
+            var code = @"
+        func main() {
+            x = 2;
+            y = 1;
+            result = x switch {
+                1 => (func() { return ""One""; })(),
+                2 => y switch {
+                    1 => (func() { return ""Two-One""; })(),
+                    2 => (func() { return ""Two-Two""; })(),
+                    _ => ""Two-Other""
+                },
+                _ => ""Other""
+            };
+            return result;
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal("Two-One", result.AsString());
+        }
+
+        [Fact]
+        public void SwitchExpression_ReturningListOfLambdas()
+        {
+            var code = @"
+        func main() {
+            type = ""math"";
+            operations = type switch {
+                ""math"" => [
+                    func(x) { return x + 1; },
+                    func(x) { return x * 2; }
+                ],
+                ""string"" => [
+                    func(x) { return x; }
+                ],
+                _ => []
+            };
+            return operations[0](5) + operations[1](3);
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(12, result.AsNumber()); // 6 + 6
+        }
+
+        [Fact]
+        public void SwitchExpression_WithHigherOrderFunction()
+        {
+            var code = @"
+        func main() {
+            apply = func(fn, value) { return fn(value); };
+            operation = ""triple"";
+            result = apply(
+                operation switch {
+                    ""double"" => func(x) { return x * 2; },
+                    ""triple"" => func(x) { return x * 3; },
+                    _ => func(x) { return x; }
+                },
+                4
+            );
+            return result;
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(12, result.AsNumber());
+        }
+
+        [Fact]
+        public void SwitchExpression_ChainedLambdaCalls()
+        {
+            var code = @"
+        func main() {
+            stage = 1;
+            process = stage switch {
+                1 => func(x) { return func(y) { return x + y; }; },
+                2 => func(x) { return func(y) { return x * y; }; },
+                _ => func(x) { return func(y) { return 0; }; }
+            };
+            return process(5)(3);
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(8, result.AsNumber());
+        }
+
+        [Fact]
+        public void SwitchExpression_WithRecursiveLambda()
+        {
+            var code = @"
+        func main() {
+            type = ""factorial"";
+            compute = type switch {
+                ""factorial"" => func(n) {
+                    if (n <= 1) { return 1; }
+                    return n * compute(n - 1);
+                },
+                ""sum"" => func(n) {
+                    if (n <= 0) { return 0; }
+                    return n + compute(n - 1);
+                },
+                _ => func(n) { return 0; }
+            };
+            return compute(5);
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(120, result.AsNumber());
+        }
+
+        [Fact]
+        public void SwitchExpression_MatchingOnLambdaEquality()
+        {
+            var code = @"
+        func main() {
+            fn1 = func() { return 1; };
+            fn2 = func() { return 2; };
+            target = fn1;
+            
+            result = target switch {
+                fn1 => ""First function"",
+                fn2 => ""Second function"",
+                _ => ""Unknown function""
+            };
+            return result;
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal("First function", result.AsString());
+        }
+
+        [Fact]
+        public void SwitchExpression_AfterVariable()
+        {
+            var code = @"
+        x = 2;
+        result = x switch {
+            1 => ""One"",
+            2 => ""Two"",
+            3 => ""Three"",
+            _ => ""Other""
+        };
+        return result;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal("Two", result.AsString());
+        }
+
+        [Fact]
+        public void SwitchExpression_WithNumericResults()
+        {
+            var code = @"
+        grade = 'B';
+        points = grade switch {
+            'A' => 4,
+            'B' => 3,
+            'C' => 2,
+            'D' => 1,
+            _ => 0
+        };
+        return points;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal(3, result.AsNumber());
+        }
+
+        [Fact]
+        public void SwitchExpression_WithDefault_NoMatch()
+        {
+            var code = @"
+        value = 99;
+        result = value switch {
+            1 => ""One"",
+            2 => ""Two"",
+            _ => ""Default""
+        };
+        return result;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal("Default", result.AsString());
+        }
+
+        [Fact]
+        public void SwitchExpression_SingleCase()
+        {
+            var code = @"
+        x = 42;
+        result = x switch {
+            42 => ""Answer"",
+            _ => ""Not Answer""
+        };
+        return result;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal("Answer", result.AsString());
+        }
+
+        [Fact]
+        public void SwitchExpression_OnlyDefault()
+        {
+            var code = @"
+        x = 123;
+        result = x switch {
+            _ => ""Always This""
+        };
+        return result;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal("Always This", result.AsString());
+        }
+
+        [Fact]
+        public void SwitchExpression_Nested()
+        {
+            var code = @"
+        x = 1;
+        y = 2;
+        result = x switch {
+            1 => y switch {
+                1 => ""One-One"",
+                2 => ""One-Two"",
+                _ => ""One-Other""
+            },
+            2 => ""Two"",
+            _ => ""Other""
+        };
+        return result;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal("One-Two", result.AsString());
+        }
+
+        [Fact]
+        public void SwitchExpression_InFunctionCall()
+        {
+            var code = @"
+            func double(n) { return n * 2; }
+            func main() {
+                x = 5;
+                result = double(x switch {
+                    5 => 10,
+                    10 => 20,
+                    _ => 0
+                });
+                return result;
+            }
+            ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(20, result.AsNumber());
+        }
+
+        [Fact]
+        public void SwitchExpression_ChainedWithIndexer()
+        {
+            var code = @"
+        arr = [""zero"", ""one"", ""two""];
+        x = 1;
+        result = arr[x switch {
+            0 => 0,
+            1 => 1,
+            2 => 2,
+            _ => 0
+        }];
+        return result;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal("one", result.AsString());
+        }
+
+        [Fact]
+        public void SwitchExpression_InBinaryExpression()
+        {
+            var code = @"
+        x = 2;
+        result = (x switch {
+            1 => 10,
+            2 => 20,
+            _ => 0
+        }) + 5;
+        return result;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal(25, result.AsNumber());
+        }
+
+        [Fact]
+        public void SwitchExpression_BooleanConditions()
+        {
+            var code = @"
+        isActive = true;
+        status = isActive switch {
+            true => ""Active"",
+            false => ""Inactive""
+        };
+        return status;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal("Active", result.AsString());
+        }
+
+        [Fact]
+        public void SwitchExpression_WithStrings()
+        {
+            var code = @"
+        day = ""Monday"";
+        type = day switch {
+            ""Monday"" => ""Weekday"",
+            ""Tuesday"" => ""Weekday"",
+            ""Saturday"" => ""Weekend"",
+            ""Sunday"" => ""Weekend"",
+            _ => ""Unknown""
+        };
+        return type;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal("Weekday", result.AsString());
+        }
+
+        [Fact]
+        public void SwitchExpression_MultipleDefaults_ShouldFail()
+        {
+            var code = @"
+        x = 1;
+        result = x switch {
+            1 => ""One"",
+            _ => ""Default1"",
+            _ => ""Default2""
+        };
+        return result;
+    ";
+            var interpreter = SetupInterpreter(code);
+            // Should fail during parsing or interpretation
+            Assert.Throws<Exception>(() => interpreter.Interpret());
+        }
+
+        [Fact]
+        public void SwitchExpression_AfterFunctionCall()
+        {
+            var code = @"
+        func getValue() { return 3; }
+        func main() {
+            result = getValue() switch {
+            1 => ""One"",
+            2 => ""Two"",
+            3 => ""Three"",
+            _ => ""Other""
+            };
+            return result;
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal("Three", result.AsString());
+        }
+
+        [Fact]
+        public void SwitchExpression_WithExpressionResults()
+        {
+            var code = @"
+        x = 3;
+        y = 5;
+        result = x switch {
+            1 => y + 1,
+            2 => y * 2,
+            3 => y - 2,
+            _ => 0
+        };
+        return result;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal(3, result.AsNumber());
+        }
+
+        [Fact]
+        public void SwitchExpression_AfterLiteral()
+        {
+            var code = @"
+            result = 3 switch {
+                1 => ""One"",
+                2 => ""Two"",
+                _ => ""Other""
+            };
+            return result;
+            ";
+
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal("Other", result.AsString());  // 3 does not match any specific case, so it returns 'Other'
+        }
+
+        [Fact]
         public void SwitchStatement_MixedBracedAndUnbraced()
         {
             var code = @"


### PR DESCRIPTION
Add switch expressions as postfix operations, allowing pattern matching syntax like `value switch { 1 => "one", 2 => "two", _ => "other" }`.

Switch expressions are now properly handled in the postfix operator loop alongside function calls and indexers, enabling chaining operations like `getValue() switch { ... }` and `arr[x switch { ... }]`.

Additionally, this commit properly implements closures by capturing the lexical environment when functions are created. Previously, function values only stored AST nodes without their surrounding scope, causing runtime errors when nested functions tried to access outer variables.

Changes:
- Add switch expression parsing as postfix operation in ParsePrimary()
- Fix switch expression parsing to use _currentToken instead of peeking
- Support chained function calls like process(5)(3)
- Introduce FunctionValue wrapper to store both AST and captured scope
- Add GetAllVariables() method to ScopeManager for environment capture
- Restore captured scope when executing functions with closures
- Add comprehensive test suite for switch expressions with lambdas

This replaces the previous half-baked closure implementation that would crash when inner functions referenced outer variables, as the scope would be destroyed before the function executed.