### PR TITLE
feat: Add support for local named function definitions

### DIFF
--- a/src/Betty.Core/Interpreter/ScopeManager.cs
+++ b/src/Betty.Core/Interpreter/ScopeManager.cs
@@ -5,6 +5,8 @@
         private readonly Dictionary<string, Value> _globals = new();
         private readonly Stack<Dictionary<string, Value>> _scopes = new();
 
+        public bool IsGlobalScope => _scopes.Count == 0;
+
         public void EnterScope()
         {
             _scopes.Push([]);
@@ -40,16 +42,25 @@
             }
 
             // If the variable is not a function parameter and is not found in any scope, check the globals
-            if (!isFunctionParam & _globals.ContainsKey(name))
+            if (!isFunctionParam && _globals.ContainsKey(name))
             {
                 // Update the global variable if it exists
                 _globals[name] = value;
                 return;
             }
 
-            // Otherwise, declare the variable in the current (innermost) scope
-            var currentScope = _scopes.Peek();
-            currentScope[name] = value;
+            // Otherwise, declare the variable in the current scope
+            if (_scopes.Count > 0)
+            {
+                // We're in a local scope - add to innermost scope
+                var currentScope = _scopes.Peek();
+                currentScope[name] = value;
+            }
+            else
+            {
+                // We're at global level - add to globals
+                _globals[name] = value;
+            }
         }
 
         public Value LookupVariable(string name)
@@ -76,17 +87,32 @@
         public Dictionary<string, Value> GetAllVariables()
         {
             var result = new Dictionary<string, Value>(_globals);
-
             // Add local scopes from outermost to innermost
             // so inner scopes override outer ones
-            foreach (var scope in _scopes.Reverse())
+            foreach (var scope in _scopes)
             {
                 foreach (var kvp in scope)
                 {
                     result[kvp.Key] = kvp.Value;
                 }
             }
+            return result;
+        }
 
+        // Captures only local variables (excludes globals)
+        public Dictionary<string, Value>? GetLocalVariables()
+        {
+            if (_scopes.Count == 0)
+                return null; // No local scope to capture
+
+            var result = new Dictionary<string, Value>();
+            foreach (var scope in _scopes)
+            {
+                foreach (var kvp in scope)
+                {
+                    result[kvp.Key] = kvp.Value;
+                }
+            }
             return result;
         }
     }

--- a/src/Betty.Core/Parser.cs
+++ b/src/Betty.Core/Parser.cs
@@ -7,7 +7,6 @@ namespace Betty.Core
     {
         private readonly Lexer _lexer;
         private Token _currentToken;
-        private readonly HashSet<string> _definedFunctions = [];
 
         public Parser(Lexer lexer)
         {
@@ -574,6 +573,7 @@ namespace Betty.Core
                 TokenType.Return => ParseReturnStatement(),
                 TokenType.Semicolon => ParseEmptyStatement(),
                 TokenType.Switch => ParseSwitchStatement(),
+                TokenType.Func => ParseFunctionDefinition(),
                 _ => ParseExpressionStatement()
             };
         }
@@ -628,10 +628,6 @@ namespace Betty.Core
             Consume(TokenType.Func);
             string functionName = (string)_currentToken.Value!;
             Consume(TokenType.Identifier); // Function name
-
-            // Check for duplicate function definition
-            if (!_definedFunctions.Add(functionName)) // Try to add the function name to the set
-                throw new Exception($"Function '{functionName}' is already defined.");
 
             Consume(TokenType.LParen); // Opening parenthesis
             var parameters = ParseParameters();

--- a/src/Betty.Tests/InterpreterTests/UserDefinedFunctionTests.cs
+++ b/src/Betty.Tests/InterpreterTests/UserDefinedFunctionTests.cs
@@ -231,5 +231,290 @@
 
             Assert.Equal(10, result.AsNumber());
         }
+
+        [Fact]
+        public void LocalNamedFunction_CanBeCalled()
+        {
+            var code = @"
+        func main() {
+            func greet() { return ""Hello""; }
+            return greet();
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal("Hello", result.AsString());
+        }
+
+        [Fact]
+        public void LocalNamedFunction_CanTakeArguments()
+        {
+            var code = @"
+        func main() {
+            func add(a, b) { return a + b; }
+            return add(2, 3);
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(5, result.AsNumber());
+        }
+
+        [Fact]
+        public void LocalNamedFunction_CanUseClosure()
+        {
+            var code = @"
+        func main() {
+            x = 10;
+            func multiply(y) { return x * y; }
+            return multiply(3);
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(30, result.AsNumber());
+        }
+
+        [Fact]
+        public void LocalNamedFunction_CanBeRecursive()
+        {
+            var code = @"
+        func main() {
+            func fact(n) {
+                if (n <= 1) { return 1; }
+                return n * fact(n - 1);
+            }
+            return fact(5);
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(120, result.AsNumber());
+        }
+
+        [Fact]
+        public void LocalNamedFunction_CanBeNested()
+        {
+            var code = @"
+        func main() {
+            func outer() {
+                func inner() { return 42; }
+                return inner();
+            }
+            return outer();
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(42, result.AsNumber());
+        }
+
+        [Fact]
+        public void LocalNamedFunction_CanShadowOuterFunction()
+        {
+            var code = @"
+        func main() {
+            func getValue() { return 10; }
+            x = getValue();
+            {
+                func getValue() { return 20; }
+                x = x + getValue();
+            }
+            x = x + getValue();
+            return x;
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(40, result.AsNumber()); // 10 + 20 + 10 = 40
+        }
+
+        [Fact]
+        public void LocalNamedFunction_CanAccessVariablesFromEnclosingScope()
+        {
+            var code = @"
+        func main() {
+            a = 5;
+            b = 10;
+            func compute() {
+                c = 15;
+                return a + b + c;
+            }
+            return compute();
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(30, result.AsNumber());
+        }
+
+        [Fact]
+        public void LocalNamedFunction_CanBeDefinedAfterVariableDeclaration()
+        {
+            var code = @"
+        func main() {
+            x = 5;
+            func double(n) { return n * 2; }
+            return double(x);
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(10, result.AsNumber());
+        }
+
+        [Fact]
+        public void LocalNamedFunction_CanBeCalledFromAnotherLocalFunction()
+        {
+            var code = @"
+        func main() {
+            func add(a, b) { return a + b; }
+            func addAndDouble(a, b) { return add(a, b) * 2; }
+            return addAndDouble(3, 4);
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(14, result.AsNumber());
+        }
+
+        [Fact]
+        public void LocalNamedFunction_InNestedBlocks_ProperScoping()
+        {
+            var code = @"
+        func main() {
+            result = 0;
+            {
+                func addOne() { return 1; }
+                result = result + addOne();
+            }
+            {
+                func addOne() { return 10; }
+                result = result + addOne();
+            }
+            return result;
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(11, result.AsNumber()); // 0 + 1 + 10 = 11
+        }
+
+        [Fact]
+        public void LocalNamedFunction_CanReturnAnotherFunction()
+        {
+            var code = @"
+        func main() {
+            func makeAdder(x) {
+                func adder(y) { return x + y; }
+                return adder;
+            }
+            add5 = makeAdder(5);
+            return add5(10);
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(15, result.AsNumber());
+        }
+
+        [Fact]
+        public void LocalNamedFunction_MultipleClosuresCaptureDifferentValues()
+        {
+            var code = @"
+        func main() {
+            func makeMultiplier(factor) {
+                func multiply(n) { return n * factor; }
+                return multiply;
+            }
+            double = makeMultiplier(2);
+            triple = makeMultiplier(3);
+            return double(5) + triple(5);
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(25, result.AsNumber()); // (5*2) + (5*3) = 10 + 15 = 25
+        }
+
+        [Fact]
+        public void LocalNamedFunction_CanBeAssignedToVariable()
+        {
+            var code = @"
+        func main() {
+            func greet() { return ""Hello""; }
+            fn = greet;
+            return fn();
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal("Hello", result.AsString());
+        }
+
+        [Fact]
+        public void LocalNamedFunction_ShadowsGlobalFunction()
+        {
+            var code = @"
+        func getValue() { return 100; }
+        func main() {
+            func getValue() { return 200; }
+            return getValue();
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(200, result.AsNumber());
+        }
+
+        [Fact]
+        public void LocalNamedFunction_OuterFunctionStillAccessibleAfterShadowing()
+        {
+            var code = @"
+        func getValue() { return 100; }
+        func main() {
+            outer = getValue();
+            {
+                func getValue() { return 200; }
+                inner = getValue();
+            }
+            after = getValue();
+            return outer + after;
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(200, result.AsNumber()); // 100 + 100 = 200
+        }
+
+        [Fact]
+        public void LocalNamedFunction_CanBePassedAsArgument()
+        {
+            var code = @"
+        func main() {
+            func apply(fn, value) { return fn(value); }
+            func square(x) { return x * x; }
+            return apply(square, 4);
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(16, result.AsNumber());
+        }
+
+        [Fact]
+        public void LocalNamedFunction_MixedWithLambdas()
+        {
+            var code = @"
+        func main() {
+            func named(x) { return x + 1; }
+            lambda = func(x) { return x * 2; };
+            return named(5) + lambda(5);
+        }
+    ";
+            var interpreter = SetupInterpreter(code, true);
+            var result = interpreter.Interpret();
+            Assert.Equal(16, result.AsNumber()); // 6 + 10 = 16
+        }
     }
 }


### PR DESCRIPTION
Implemented local function definitions as statements (func name() { }) that can be declared within any scope, complementing the existing lambda expression support (func() { } assigned to variables).

Changes:
- Parser: Added FunctionDefinition to statement parsing in ParseStatement()
- Parser: Removed global-only restriction from ParseFunctionDefinition()
- Interpreter: Refactored function storage to use scope manager instead of separate _functions dictionary, enabling proper shadowing behavior
- Interpreter: Named functions now stored as variables in the scope chain, allowing local functions to shadow outer definitions
- ScopeManager: Added IsGlobalScope property to distinguish global vs local scope contexts
- ScopeManager: Fixed SetVariable() to handle empty scope stack at global level

Local functions support:
- Declaration within any block scope (functions, loops, conditionals)
- Shadowing of outer functions (both global and local)
- Recursion and mutual recursion
- Access to enclosing scope variables (read-only closures)
- Being passed as arguments and returned from functions
- All standard function features (parameters, return values, nesting)

Note: Closures currently capture variables by value (read-only). Modifications to captured variables within closures do not propagate to the outer scope. This is a known limitation that may be addressed in future work.

All existing tests pass. Added comprehensive test coverage for local named function scenarios.